### PR TITLE
Fix HTML doctype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"/>
 <link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect"/>


### PR DESCRIPTION
## Summary
- add the missing `<!DOCTYPE html>` declaration so the page renders in standards mode

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a507933c88323a5dca88b4a346db4