### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link crossorigin="" href="https://fonts.gstatic.com/" rel="preconnect"/>
 <link as="style" href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Plus+Jakarta+Sans%3Awght%40400%3B500%3B700%3B800" onload="this.rel='stylesheet'" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet"/>
@@ -37,15 +38,18 @@
 </svg>
 <h2 class="text-xl font-bold leading-tight tracking-[-0.015em] text-stone-800">Shellbnb</h2>
 </div>
-<div class="flex flex-1 justify-end gap-6">
-<nav class="flex items-center gap-6">
+<div class="relative flex flex-1 items-center justify-end">
+<button id="nav-toggle" class="text-stone-600 md:hidden">
+<span class="material-symbols-outlined text-3xl">menu</span>
+</button>
+<nav id="nav-menu" class="absolute left-0 top-full z-10 hidden w-full flex-col gap-4 bg-white p-4 shadow-md md:static md:flex md:w-auto md:flex-row md:items-center md:gap-6 md:bg-transparent md:p-0 md:shadow-none">
 <a class="text-stone-600 hover:text-stone-900 text-sm font-medium leading-normal" href="#">Explore</a>
 <a class="text-stone-600 hover:text-stone-900 text-sm font-medium leading-normal" href="#">About</a>
 <a class="text-stone-600 hover:text-stone-900 text-sm font-medium leading-normal" href="#">Help</a>
-</nav>
-<button class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-6 bg-[var(--primary-500)] text-white text-sm font-bold leading-normal tracking-wide hover:bg-[var(--primary-600)] transition-colors">
+<button class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-6 bg-[var(--primary-500)] text-white text-sm font-bold leading-normal tracking-wide hover:bg-[var(--primary-600)] transition-colors md:ml-4">
 <span class="truncate">Become a Host</span>
 </button>
+</nav>
 </div>
 </header>
 <main class="flex flex-1 justify-center py-10 px-4 sm:px-10">
@@ -53,8 +57,8 @@
 <section class="relative flex min-h-[480px] flex-col items-center justify-center gap-8 rounded-2xl bg-cover bg-center bg-no-repeat p-8 text-center" style='background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.5)), url("https://lh3.googleusercontent.com/aida-public/AB6AXuDtNtPuXHko8B55ukK8mD6xuoZ4Is68ZvrJbpeGvczNbzG28oMGLnf8V4nHVUAXqn1eQSLp2fD9RfmuLqWR4Z7urh2bMCXqdyNb9Ij6gQ49NKrTISI5GQWMglkxjdUfRIfVpjneNG8gujsn6b0J-_akVQOPGSfWa91aovd5P1fMIMd7jig9piCw0HzJkvS4yZfVEDWXvX9guIeXeS96ETzQY8fJutfxqXKOgmjdRolwavpgS9bYKrmigpkVVUB1v9DuTAxZHKQUYiI");'>
 <img alt="Smiling turtle with a travel bag" class="absolute bottom-0 right-8 h-40 w-40" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAytrfVs0g630xVA9wq5AxJvjMVS9ChuhmHfQ16egd8inBb7K8yPZKXirzfo382b2aPCfTnzRIwa5BZoOG8QQVe_HcyiG2ZKszCGeRu9fjyMzZNEVTGmgnonkHmfbPh2Lx9S0tB9EPkcLLUOFWwbS1zHoOnMtticACfQAmfvbP8gveEgcRNF58yqhViB6ylB_oqD4uh_tSvgNuD_E7NjsPeoEN7pFK0PWuGF3x2AzsvT55beK-hgKIacXWOn7aTbn7_aiPMO_HKyO4"/>
 <div class="flex flex-col gap-4">
-<h1 class="text-white text-5xl font-black leading-tight tracking-tighter">Find Your Perfect Shell Away From Home</h1>
-<h2 class="text-white text-lg font-normal leading-normal">Whether you're migrating or just napping, discover your next cozy retreat.</h2>
+<h1 class="text-white text-3xl sm:text-5xl font-black leading-tight tracking-tighter">Find Your Perfect Shell Away From Home</h1>
+<h2 class="text-white text-base sm:text-lg font-normal leading-normal">Whether you're migrating or just napping, discover your next cozy retreat.</h2>
 </div>
 <form class="flex w-full max-w-xl flex-col items-center gap-4 rounded-full bg-white/20 p-2 backdrop-blur-sm sm:flex-row">
 <div class="flex h-14 w-full flex-1 items-center rounded-full bg-white px-5 shadow-md">
@@ -254,4 +258,9 @@
 </div>
 </div>
 
+<script>
+  document.getElementById('nav-toggle').addEventListener('click', function () {
+    document.getElementById('nav-menu').classList.toggle('hidden');
+  });
+</script>
 </body></html>


### PR DESCRIPTION
## Summary
- add meta viewport tag
- scale hero text down on small screens for better readability
- convert navigation to a hamburger menu on mobile

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687a7df159d08323aeca469461138807