### PR TITLE
Revamp hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,27 +56,26 @@
 </header>
 <main class="flex flex-1 justify-center py-10 px-4 sm:px-10">
 <div class="layout-content-container flex flex-col max-w-screen-2xl flex-1 gap-12">
-<section class="relative flex min-h-[480px] flex-col items-center justify-center gap-8 rounded-2xl bg-cover bg-center bg-no-repeat p-6 sm:p-8 text-center" style='background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.7)), url("https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&q=80");'>
-<div class="flex flex-col gap-4">
-<h1 class="text-white text-3xl sm:text-5xl font-black leading-tight tracking-tighter">Find Your Perfect Shell Away From Home</h1>
-<h2 class="text-white text-base sm:text-lg font-normal leading-normal">Whether you're migrating or just napping, discover your next cozy retreat.</h2>
-</div>
-<form class="flex w-full max-w-xl flex-col items-center gap-4 rounded-full bg-white/20 p-2 backdrop-blur-sm sm:flex-row">
-<div class="flex h-14 w-full flex-1 items-center rounded-full bg-white px-5 shadow-md">
-<input class="form-input w-full flex-1 border-none bg-transparent text-stone-800 placeholder:text-stone-500 focus:ring-0" placeholder="Search destinations" type="text"/>
-<div class="h-6 border-l border-stone-200"></div>
-<select class="form-select border-none bg-transparent text-stone-500 focus:ring-0">
-<option>Beach</option>
-<option>Pond</option>
-<option>Forest</option>
-<option>Desert</option>
-</select>
-</div>
-<button class="flex h-14 w-full items-center justify-center gap-2 rounded-full bg-[var(--primary-500)] px-8 text-white hover:bg-[var(--primary-600)] sm:w-auto" type="submit">
-<span class="material-symbols-outlined"> search </span>
-<span class="font-semibold">Search</span>
-</button>
-</form>
+<section class="relative z-10 mx-auto flex h-[160px] w-full max-w-screen-lg flex-col items-center justify-start gap-4 rounded-2xl bg-white/85 p-6 backdrop-blur-sm sm:p-8">
+  <form class="flex w-full items-center gap-4 rounded-full bg-white px-4 py-2 shadow-md sm:gap-6">
+    <input class="form-input flex-1 border-none bg-transparent placeholder:text-stone-500 focus:ring-0" placeholder="Search destinations" type="text"/>
+    <select class="form-select border-none bg-transparent text-stone-500 focus:ring-0">
+      <option>Beach</option>
+      <option>Pond</option>
+      <option>Reef</option>
+      <option>Log</option>
+    </select>
+    <button class="flex items-center justify-center rounded-full bg-[var(--primary-500)] px-4 py-2 font-bold text-white" type="submit">
+      <span class="material-symbols-outlined">search</span>
+    </button>
+  </form>
+  <div class="flex w-full max-w-full items-center gap-6 overflow-x-auto border-t border-stone-200 pt-4 text-sm">
+    <a class="flex min-w-fit flex-col items-center gap-1 text-stone-600 hover:text-stone-900" href="#"><span class="text-xl">🐚</span><span>Shells</span></a>
+    <a class="flex min-w-fit flex-col items-center gap-1 text-stone-600 hover:text-stone-900" href="#"><span class="text-xl">🪵</span><span>Logs</span></a>
+    <a class="flex min-w-fit flex-col items-center gap-1 text-stone-600 hover:text-stone-900" href="#"><span class="text-xl">🌊</span><span>Reefs</span></a>
+    <a class="flex min-w-fit flex-col items-center gap-1 text-stone-600 hover:text-stone-900" href="#"><span class="text-xl">🪴</span><span>Nests</span></a>
+    <a class="flex min-w-fit flex-col items-center gap-1 text-stone-600 hover:text-stone-900" href="#"><span class="text-xl">🐢</span><span>Top Hosts</span></a>
+  </div>
 </section>
 <section class="flex flex-col gap-6">
   <h2 class="text-stone-800 text-3xl font-bold leading-tight tracking-tight">Popular Shells Near You</h2>


### PR DESCRIPTION
## Summary
- simplify the hero section with a short translucent container
- add an Airbnb‑style search bar
- include a turtle category row under the search bar

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687aa03702608323a72569e0e28e7f3e