### PR TITLE
Fix tooltip visibility over search bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.2s;
-        z-index: 10;
+        z-index: 20;
       }
       .category-item:hover::after {
         opacity: 1;


### PR DESCRIPTION
## Summary
- ensure category tooltips appear above the search bar by increasing their z-index

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687aadfb9164832392f3d4bb15424002