### PR TITLE
Fix tooltip placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
       .category-item::after {
         content: attr(data-tooltip);
         position: absolute;
-        bottom: 120%;
+        top: 120%;
         left: 50%;
         transform: translateX(-50%);
         background: rgba(0,0,0,0.8);
@@ -121,7 +121,7 @@
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.2s;
-        z-index: 10;
+        z-index: 20;
       }
       .category-item:hover::after {
         opacity: 1;


### PR DESCRIPTION
## Summary
- show tooltips below category items so they don't overlap the search bar

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687aadfb9164832392f3d4bb15424002