### PR TITLE
Fix lily pad image

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
 
     <a href="#" class="card group relative flex flex-col overflow-hidden rounded-xl border border-stone-200 bg-white shadow-sm transition-shadow hover:shadow-lg">
       <div class="relative">
-        <img class="card-img transition-transform group-hover:scale-105" loading="lazy" alt="Lily Pad Lookout" src="https://images.unsplash.com/photo-1533569724892-8b97c93fa631?auto=format&fit=crop&w=640&q=80" onerror="this.src='https://via.placeholder.com/640x480?text=Shellbnb'" />
+        <img class="card-img transition-transform group-hover:scale-105" loading="lazy" alt="Lily Pad Lookout" src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=640&q=80" onerror="this.src='https://via.placeholder.com/640x480?text=Shellbnb'" />
         <button aria-label="Save to favorites" title="Save to favorites" class="heart-btn">
           <span class="material-symbols-outlined text-red-500">favorite</span>
         </button>


### PR DESCRIPTION
## Summary
- replace lily pad listing image URL with another Unsplash link

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ab01281a4832391a100813e538451