### PR TITLE
Fix cursor canvas height

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 </head>
 <body class="bg-[#fcfdfb]">
 <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden" style='font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;'>
-<canvas id="cursor-canvas" class="pointer-events-none absolute inset-0 -z-10"></canvas>
+<canvas id="cursor-canvas" class="pointer-events-none fixed inset-0 -z-10"></canvas>
 <div id="mascot-container" class="pointer-events-auto absolute left-0 top-0 w-16 h-12" style="cursor:grab">
   <svg id="turtle" viewBox="0 0 64 32" xmlns="http://www.w3.org/2000/svg" class="w-full h-full select-none">
     <ellipse cx="24" cy="16" rx="16" ry="12" fill="#68a23f"/>
@@ -970,6 +970,19 @@
   resize();
   loop();
 })();
+</script>
+<script>
+  // Re-size the canvas to full document height
+  function resizeCursorCanvas() {
+    const c = document.getElementById('cursor-canvas');
+    const dpr = window.devicePixelRatio || 1;
+    c.width  = window.innerWidth  * dpr;
+    c.height = document.documentElement.scrollHeight * dpr;
+    c.style.width  = window.innerWidth  + 'px';
+    c.style.height = document.documentElement.scrollHeight + 'px';
+  }
+  window.addEventListener('load', resizeCursorCanvas);
+  window.addEventListener('resize', resizeCursorCanvas);
 </script>
 
 <script>


### PR DESCRIPTION
## Summary
- make cursor canvas fixed so it follows the pointer while scrolling
- resize cursor canvas to cover entire document on load and resize

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e476b316c8323b225410293a3c105