### PR TITLE
Fix search icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
       <option>4 guests</option>
       <option>5+ guests</option>
     </select>
-    <button aria-label="Search" class="h-12 w-full sm:w-12 rounded-full bg-green-500 text-white transition-transform hover:scale-105" type="submit">
+    <button aria-label="Search" class="h-12 w-full sm:w-12 rounded-full bg-green-500 text-white transition-transform hover:scale-105 flex items-center justify-center" type="submit">
       <span class="material-symbols-outlined">search</span>
     </button>
   </form>


### PR DESCRIPTION
## Summary
- center the search icon within the search button

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_687e6b8ffbe88323810a6c4648821056